### PR TITLE
S3 backend: add capability to delete S3 objects

### DIFF
--- a/chapter6/part1_s3backend/iam.tf
+++ b/chapter6/part1_s3backend/iam.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "policy_doc" {
   }
 
   statement {
-    actions = ["s3:GetObject", "s3:PutObject"]
+    actions = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
 
     resources = [
       "${aws_s3_bucket.s3_bucket.arn}/*",


### PR DESCRIPTION
Without it, it's not possible to delete a workspace:
```
$ terraform workspace delete prod
AccessDenied: Access Denied
	status code: 403, request id: XXXXXX, host id: XXXXXX
```