### PR TITLE
Fix syntax error in local block of listing 3.7/madlibs.tf

### DIFF
--- a/chapter3/listing3.7/madlibs.tf
+++ b/chapter3/listing3.7/madlibs.tf
@@ -16,7 +16,7 @@ variable "num_files" {
 
 locals {
   uppercase_words = {for k,v in var.words : k => [for s in v : upper(s)]}
-    }
+}
 
 resource "random_shuffle" "random_nouns" {
   count = var.num_files

--- a/chapter3/listing3.7/madlibs.tf
+++ b/chapter3/listing3.7/madlibs.tf
@@ -16,7 +16,7 @@ variable "num_files" {
 
 locals {
   uppercase_words = {for k,v in var.words : k => [for s in v : upper(s)]}
-
+    }
 
 resource "random_shuffle" "random_nouns" {
   count = var.num_files


### PR DESCRIPTION
# Description
There's a syntax error in `chapter3/listing 3.7/madlibs.tf`

Just a missing closing bracket on the local block

I'm unable to remove the newline I added at the end of the file, but I don't think it has an effect

## Screenshot of the error from `terraform init`
<img width="533" alt="image" src="https://user-images.githubusercontent.com/5882512/134734534-9213a17d-bfda-44b2-95a2-0880619c8796.png">


# Screenshot of the book
<img width="763" alt="image" src="https://user-images.githubusercontent.com/5882512/134734492-0b0f5845-0c55-4c7e-96ea-ccb09e6afcd1.png">
