### PR TITLE
Standard_A1_v2 and reduce server/client count for chapter 8

### DIFF
--- a/chapter8/part2a_multicloud-mmorpg/main.tf
+++ b/chapter8/part2a_multicloud-mmorpg/main.tf
@@ -53,16 +53,16 @@ module "azure" {
 
   consul = {
     version              = "1.9.2"
-    servers_count        = 3
-    server_instance_size = "Standard_A1"
+    servers_count        = 1
+    server_instance_size = "Standard_A1_v2"
   }
 
   nomad = {
     version              = "1.0.3"
-    servers_count        = 3
-    server_instance_size = "Standard_A1"
-    clients_count        = 3
-    client_instance_size = "Standard_A1"
+    servers_count        = 1
+    server_instance_size = "Standard_A1_v2"
+    clients_count        = 1
+    client_instance_size = "Standard_A1_v2"
   }
 }
 


### PR DESCRIPTION
I kept getting this error, maybe azure reduced it's free tier limits
```
module.azure.module.consul_servers.azurerm_role_assignment.role_assignment: Creating...
module.azure.module.consul_servers.azurerm_monitor_autoscale_setting.autoscale_setting: Creating...
module.azure.module.consul_servers.azurerm_monitor_autoscale_setting.autoscale_setting: Creation complete after 5s [id=/subscriptions/6e1e9c04-876e-49bf-be7e-da7e1c0d0d76/resourceGroups/terraforminaction-6fy8a6/providers/microsoft.insights/autoscalesettings/terraforminaction-6fy8a6-Ndisabled-Cserver-AutoscaleSetting]
module.azure.module.consul_servers.azurerm_role_assignment.role_assignment: Still creating... [10s elapsed]
module.azure.module.consul_servers.azurerm_role_assignment.role_assignment: Still creating... [20s elapsed]
module.azure.module.consul_servers.azurerm_role_assignment.role_assignment: Creation complete after 23s [id=/subscriptions/6e1e9c04-876e-49bf-be7e-da7e1c0d0d76/providers/Microsoft.Authorization/roleAssignments/d25d19d0-6100-18f9-fb56-c2a4c9f74916]
╷
│ Error: compute.VirtualMachineScaleSetsClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="PublicIPCountLimitExceededByVMScaleSet" Message="The requested number of publicIPAddresses 4 for VM Scale Set /subscriptions/6e1e9c04-876e-49bf-be7e-da7e1c0d0d76/resourceGroups/TERRAFORMINACTION-6FY8A6/providers/Microsoft.Compute/virtualMachineScaleSets/terraforminaction-6fy8a6-Nserver-Cclient will exceed the maximum number of publicIPAddresses allowed 10 for subscription 6e1e9c04-876e-49bf-be7e-da7e1c0d0d76." Details=[] InnerError={"errorDetail":"{\r\n  \"error\": {\r\n    \"code\": \"PublicIPCountLimitExceededByVMScaleSet\",\r\n    \"message\": \"The requested number of publicIPAddresses 4 for VM Scale Set /subscriptions/6e1e9c04-876e-49bf-be7e-da7e1c0d0d76/resourceGroups/TERRAFORMINACTION-6FY8A6/providers/Microsoft.Compute/virtualMachineScaleSets/terraforminaction-6fy8a6-Nserver-Cclient will exceed the maximum number of publicIPAddresses allowed 10 for subscription 6e1e9c04-876e-49bf-be7e-da7e1c0d0d76.\",\r\n    \"details\": [],\r\n    \"innerError\": \"Source: Nrp.Frontend.Contract. Microsoft.WindowsAzure.Networking.Nrp.Frontend.Common.ValidationException: The requested number of publicIPAddresses 4 for VM Scale Set /subscriptions/6e1e9c04-876e-49bf-be7e-da7e1c0d0d76/resourceGroups/TERRAFORMINACTION-6FY8A6/providers/Microsoft.Compute/virtualMachineScaleSets/terraforminaction-6fy8a6-Nserver-Cclient will exceed the maximum number of publicIPAddresses allowed 10 for subscription 6e1e9c04-876e-49bf-be7e-da7e1c0d0d76.\\r\\n   at Microsoft.WindowsAzure.Networking.Nrp.Frontend.Contract.Internal.VMScaleSet.Validate(VMScaleSet existingResource, Subscription subscription, Dictionary`2 referencedResources, String apiVersion, Subscription computeSubscription, ILogger logger, ResourceReferenceResolver resourceReferenceResolver, String clientAppId, HashSet`1 remoteAllowedSubscriptions) in X:\\\\bt\\\\1121847\\\\repo\\\\src\\\\sources\\\\Frontend\\\\FrontendContract\\\\Internal\\\\VMScaleSet.cs:line 1041\\r\\n   at Microsoft.WindowsAzure.Networking.Nrp.Frontend.Operations.Internal.ValidateVMScaleSetOperation.\u003cExecuteAsync\u003ed__31.MoveNext() in X:\\\\bt\\\\1121847\\\\repo\\\\src\\\\sources\\\\Frontend\\\\FrontEndOperations\\\\Internal\\\\ValidateVMScaleSetOperation.cs:line 442\\r\\n--- End of stack trace from previous location where exception was thrown ---\\r\\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\\r\\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\\r\\n   at Microsoft.WindowsAzure.Networking.Nrp.Frontend.Operations.OperationBase`1.\u003cRunAsync\u003ed__64.MoveNext() in X:\\\\bt\\\\1121847\\\\repo\\\\src\\\\sources\\\\Frontend\\\\FrontEndOperations\\\\OperationBase.cs:line 0\"\r\n  }\r\n}"}
│ 
│   with module.azure.module.nomad_servers.azurerm_virtual_machine_scale_set.scale_set,
│   on .terraform/modules/azure/modules/cluster/main.tf line 50, in resource "azurerm_virtual_machine_scale_set" "scale_set":
│   50: resource "azurerm_virtual_machine_scale_set" "scale_set" {
│ 
╵
╷
│ Error: compute.VirtualMachineScaleSetsClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code="OperationNotAllowed" Message="Operation could not be completed as it results in exceeding approved Total Regional Cores quota. Additional details - Deployment Model: Resource Manager, Location: centralus, Current Limit: 4, Current Usage: 4, Additional Required: 1, (Minimum) New Limit Required: 5. Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/CapacityExperienceBlade/Parameters/%7B%22subscriptionId%22:%226e1e9c04-876e-49bf-be7e-da7e1c0d0d76%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22centralus%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22cores%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:5,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22cores%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/regional-quota-requests"
│ 
│   with module.azure.module.nomad_clients.azurerm_virtual_machine_scale_set.scale_set,
│   on .terraform/modules/azure/modules/cluster/main.tf line 50, in resource "azurerm_virtual_machine_scale_set" "scale_set":
│   50: resource "azurerm_virtual_machine_scale_set" "scale_set" {
│ 
╵

```

the Standard_A1_v2 is similar to this pr, Standard_A1 isn't available:
https://github.com/terraform-in-action/terraform-cloud-vm/pull/1