### PR TITLE
update listing 9.1 to remove duplicate aws provider

### DIFF
--- a/chapter9/listing9.1/blue_green.tf
+++ b/chapter9/listing9.1/blue_green.tf
@@ -2,10 +2,6 @@ provider "aws" {
   region  = "us-west-2"
 }
 
-provider "aws" {
-  region  = "us-west-2"
-}
-
 variable "production" {
   default = "green"
 }


### PR DESCRIPTION
Received this error while running `terraform init`:
```
Dustins-MacBook-Pro:listing9.1 dustinalandzes$ terraform init
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.
╷
│ Error: Duplicate provider configuration
│ 
│   on blue_green.tf line 5:
│    5: provider "aws" {
│ 
│ A default (non-aliased) provider configuration for "aws" was already given at blue_green.tf:1,1-15. If multiple configurations are required, set the "alias" argument for alternative configurations.
╵
```

the book doesn't have this duplicate provider:
<img width="760" alt="image" src="https://user-images.githubusercontent.com/5882512/137799854-a846663d-b25d-4b99-9a98-7cafc6291399.png">
