### PR TITLE
use app.yml instead of dev.yml on listing 9.11

### DIFF
--- a/chapter9/listing9.11/main.tf
+++ b/chapter9/listing9.11/main.tf
@@ -84,7 +84,7 @@ resource "aws_instance" "ansible_server" {
   }
   
   provisioner "local-exec" {
-    command = "ansible-playbook -u ubuntu --key-file ansible-key.pem -T 300 -i '${self.public_ip},', dev.yml" 
+    command = "ansible-playbook -u ubuntu --key-file ansible-key.pem -T 300 -i '${self.public_ip},', app.yml" 
   }
 }
 


### PR DESCRIPTION
I got this error while running `terraform apply`:
```
aws_instance.ansible_server: Provisioning with 'local-exec'...
aws_instance.ansible_server (local-exec): Executing: ["/bin/sh" "-c" "ansible-playbook -u ubuntu --key-file ansible-key.pem -T 300 -i '35.85.232.123,', dev.yml"]
aws_instance.ansible_server (local-exec): ERROR! the playbook: dev.yml could not be found
╷
│ Error: local-exec provisioner error
│ 
│   with aws_instance.ansible_server,
│   on main.tf line 86, in resource "aws_instance" "ansible_server":
│   86:   provisioner "local-exec" {
│ 
│ Error running command 'ansible-playbook -u ubuntu --key-file ansible-key.pem -T 300 -i '35.85.232.123,', dev.yml': exit status 1. Output: ERROR! the playbook: dev.yml could not be found
│ 
╵
```

the book only uses app.yml:
<img width="768" alt="image" src="https://user-images.githubusercontent.com/5882512/137806734-4b13b49f-f65f-4024-b84d-67728c724b96.png">
