### PR TITLE
Remove the pessimistic constraint operator from terraform's required_version (~> 0.13) in chapter 10

### DIFF
--- a/chapter10/complete-part1/main.tf
+++ b/chapter10/complete-part1/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.13"
+  required_version = "> 0.13"
   required_providers {
     aws   = "~> 3.6"
     local = "~> 1.4"


### PR DESCRIPTION
~> doesn't allow the latest version of terraform (1.0.9)
https://www.terraform.io/docs/language/expressions/version-constraints.html

"~>: Allows only the rightmost version component to increment. For example, to allow new patch releases within a specific minor release, use the full version number: ~> 1.0.4 will allow installation of 1.0.5 and 1.0.10 but not 1.1.0. This is usually called the pessimistic constraint operator."

I got this error before changing the version after running `terraform init`
```
Dustins-MBP:complete-part2 dustinalandzes$ terraform init
Initializing modules...
- iam in modules/iam
╷
│ Error: Unsupported Terraform Core version
│ 
│   on main.tf line 2, in terraform:
│    2:   required_version = "~> 0.13"
│ 
│ This configuration does not support Terraform version 1.0.7. To proceed, either choose another supported Terraform version or update this version constraint. Version constraints are normally set for good reason, so
│ updating the constraint may lead to other errors or unexpected behavior.
╵
```

and this after
```
Dustins-MBP:complete-part2 dustinalandzes$ terraform init
Initializing modules...

Initializing the backend...

Initializing provider plugins...
- Finding hashicorp/local versions matching "~> 1.4"...
- Finding hashicorp/aws versions matching "~> 3.6"...
- Installing hashicorp/local v1.4.0...
- Installed hashicorp/local v1.4.0 (signed by HashiCorp)
- Installing hashicorp/aws v3.63.0...
- Installed hashicorp/aws v3.63.0 (signed by HashiCorp)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```

I'm on v1.0.7 right now
```
Dustins-MBP:complete-part2 dustinalandzes$ terraform --version
Terraform v1.0.7
on darwin_amd64
+ provider registry.terraform.io/hashicorp/aws v3.63.0
+ provider registry.terraform.io/hashicorp/local v1.4.0

Your version of Terraform is out of date! The latest version
is 1.0.9. You can update by downloading from https://www.terraform.io/downloads.html
```