### PR TITLE
Update outputs.tf

### DIFF
--- a/chapter4/listing4.20/outputs.tf
+++ b/chapter4/listing4.20/outputs.tf
@@ -1,5 +1,6 @@
 output "db_password" {
   value = module.database.db_config.password
+  sensitive = true 
 }
 
 output "lb_dns_name" {


### PR DESCRIPTION
I needed to add this line: "sensitive=true" in the output "db_password" block, otherwise it throws this error:
│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 2:
│    2: output "db_password" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was intended to be only internal, Terraform requires that any root module output
│ containing sensitive data be explicitly marked as sensitive, to confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as sensitive by adding the following argument:
│     sensitive = true