### PR TITLE
Fix small typos

### DIFF
--- a/chapter12/listing12.12/main.tf
+++ b/chapter12/listing12.12/main.tf
@@ -80,3 +80,4 @@ resource "aws_codepipeline" "codepipeline" {
       }
     }
   }
+}

--- a/chapter7/listing7.14/main_test.go
+++ b/chapter7/listing7.14/main_test.go
@@ -21,4 +21,3 @@ func TestGETIndex(t *testing.T) {
 		}
 	})
 }
-Now 


### PR DESCRIPTION
Small fixes:

- Paragraph text at the end of a go code sample
- missing ending bracket for a terraform resource